### PR TITLE
fix: remove event listener after page leave

### DIFF
--- a/components/Apps/Tetris/index.tsx
+++ b/components/Apps/Tetris/index.tsx
@@ -12,7 +12,13 @@ export const TetrisGame: FC = () => {
 	const [lose, setLose] = useState(false);
 
 	useEffect(() => {
-		document.onkeydown = (e) => e.preventDefault();
+		const handleKeyDown = (e: KeyboardEvent) => e.preventDefault();
+
+		window.addEventListener("keydown", handleKeyDown);
+
+		return () => {
+			window.removeEventListener("keydown", handleKeyDown);
+		};
 	}, []);
 
 	return (
@@ -27,7 +33,7 @@ export const TetrisGame: FC = () => {
 					state,
 					controller,
 				}) => (
-					<div className="min-h-screen flex relative items-center flex-col">
+					<div className="relative flex flex-col items-center min-h-screen">
 						<>
 							<div className="flex mb-4 ">
 								<div className="w-1/2 px-2">
@@ -54,11 +60,11 @@ export const TetrisGame: FC = () => {
 									<PieceQueue />
 								</div>
 							</div>
-							<div className="grid grid-cols-2 gap-4 md:flex mb-4 ">
+							<div className="grid grid-cols-2 gap-4 mb-4 md:flex ">
 								<div className="md:w-1/5">
 									<button
 										onClick={controller.moveLeft}
-										className="inline-block mb-3 lg:mb-0  w-full py-2 px-6 leading-loose bg-blue-600 hover:bg-blue-700 text-white font-semibold round transition duration-200"
+										className="inline-block w-full px-6 py-2 mb-3 font-semibold leading-loose text-white transition duration-200 bg-blue-600 lg:mb-0 hover:bg-blue-700 round"
 									>
 										{parser.get("left")}
 									</button>
@@ -66,7 +72,7 @@ export const TetrisGame: FC = () => {
 								<div className="md:w-1/5">
 									<button
 										onClick={controller.moveRight}
-										className="inline-block mb-3 lg:mb-0  w-full  py-2 px-6 leading-loose bg-blue-600 hover:bg-blue-700 text-white font-semibold round transition duration-200"
+										className="inline-block w-full px-6 py-2 mb-3 font-semibold leading-loose text-white transition duration-200 bg-blue-600 lg:mb-0 hover:bg-blue-700 round"
 									>
 										{parser.get("right")}
 									</button>
@@ -74,7 +80,7 @@ export const TetrisGame: FC = () => {
 								<div className="md:w-1/5">
 									<button
 										onClick={controller.flipClockwise}
-										className="inline-block mb-3 lg:mb-0  w-full  py-2 px-6 leading-loose bg-blue-600 hover:bg-blue-700 text-white font-semibold round transition duration-200"
+										className="inline-block w-full px-6 py-2 mb-3 font-semibold leading-loose text-white transition duration-200 bg-blue-600 lg:mb-0 hover:bg-blue-700 round"
 									>
 										{parser.get("rotate")}
 									</button>
@@ -82,7 +88,7 @@ export const TetrisGame: FC = () => {
 								<div className="md:w-1/5">
 									<button
 										onClick={controller.hardDrop}
-										className="inline-block mb-3 lg:mb-0  w-full  py-2 px-6 leading-loose bg-blue-600 hover:bg-blue-700 text-white font-semibold round transition duration-200"
+										className="inline-block w-full px-6 py-2 mb-3 font-semibold leading-loose text-white transition duration-200 bg-blue-600 lg:mb-0 hover:bg-blue-700 round"
 									>
 										{parser.get("drop")}
 									</button>
@@ -93,7 +99,7 @@ export const TetrisGame: FC = () => {
 											setLose(false);
 											controller.restart();
 										}}
-										className="inline-block mb-3 lg:mb-0  w-full lg:w-auto py-2 px-6 leading-loose bg-blue-600 hover:bg-blue-700 text-white font-semibold round transition duration-200"
+										className="inline-block w-full px-6 py-2 mb-3 font-semibold leading-loose text-white transition duration-200 bg-blue-600 lg:mb-0 lg:w-auto hover:bg-blue-700 round"
 									>
 										{parser.get("restart")}
 									</button>

--- a/components/Apps/Tetris/index.tsx
+++ b/components/Apps/Tetris/index.tsx
@@ -11,9 +11,9 @@ export const TetrisGame: FC = () => {
 
 	const [lose, setLose] = useState(false);
 
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => e.preventDefault();
+	const handleKeyDown = (e: KeyboardEvent) => e.preventDefault();
 
+	useEffect(() => {
 		window.addEventListener("keydown", handleKeyDown);
 
 		return () => {


### PR DESCRIPTION
it was preventing every keypress forever after you visit the tetris game page. i thought the webpage was broken but then realized I can't even use browser shortcuts like cmd+w to close the tab, then figured it out. here's the fix :)